### PR TITLE
refactor(live): simplify reorder client

### DIFF
--- a/src-tauri/src/commands/live.rs
+++ b/src-tauri/src/commands/live.rs
@@ -128,14 +128,6 @@ pub async fn start_live_session(
         let mut resampler = OnlineResampler::new(device_sample_rate, target_sample_rate);
         let mut tick = tokio::time::interval(Duration::from_millis(100));
 
-        // Head-of-line bound for the reorder buffer: a completion held waiting for
-        // an earlier utterance that never finishes is released after this, so a
-        // dropped segment can't stall the stream. Comfortably longer than realistic
-        // transcription latency, since a merely-slow utterance fills the gap and
-        // clears the block before the timeout is reached.
-        const REORDER_HEAD_TIMEOUT: Duration = Duration::from_millis(2500);
-        let mut reorder_blocked_since: Option<tokio::time::Instant> = None;
-
         loop {
             tokio::select! {
                 _ = tick.tick() => {
@@ -154,22 +146,11 @@ pub async fn start_live_session(
                             break;
                         }
                     }
-                    // Drive the reorder head-of-line timeout off the same tick. A
-                    // completion held behind an earlier utterance that never lands
-                    // is released after REORDER_HEAD_TIMEOUT so the stream can't
-                    // stall; a merely-slow utterance fills the gap via poll_event
-                    // and clears the block before this fires.
-                    if client.reorder_blocked() {
-                        let since = *reorder_blocked_since
-                            .get_or_insert_with(tokio::time::Instant::now);
-                        if since.elapsed() >= REORDER_HEAD_TIMEOUT {
-                            for evt in client.skip_reorder_head() {
-                                emit_utterance(&app_for_task, session_id, evt);
-                            }
-                            reorder_blocked_since = None;
-                        }
-                    } else {
-                        reorder_blocked_since = None;
+                    // Release any utterance the reorder buffer has held past its
+                    // head-of-line timeout (a dropped earlier utterance that never
+                    // arrives); the client owns the timer, the pump just ticks it.
+                    for evt in client.check_reorder_timeout(tokio::time::Instant::now()) {
+                        emit_utterance(&app_for_task, session_id, evt);
                     }
                 }
                 evt = client.poll_event() => {

--- a/src-tauri/src/transcription/streaming/realtime_openai_compatible.rs
+++ b/src-tauri/src/transcription/streaming/realtime_openai_compatible.rs
@@ -20,10 +20,18 @@ use super::providers::{AuthScheme, ProviderConfig, VadMode};
 use super::reorder::ReorderBuffer;
 use super::{SessionConfig, StreamingEvent, StreamingTranscriber, ErrorKind};
 use std::collections::VecDeque;
+use std::time::Duration;
+use tokio::time::Instant;
 
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 type WsSink = SplitSink<WsStream, Message>;
 type WsSource = SplitStream<WsStream>;
+
+/// Head-of-line bound for the reorder buffer: a completion held waiting for an
+/// earlier utterance that never finishes is released after this. Comfortably
+/// longer than realistic transcription latency, since a merely-slow utterance
+/// fills the gap (via `poll_event`) and disarms the timer before it fires.
+const REORDER_HEAD_TIMEOUT: Duration = Duration::from_millis(2500);
 
 pub struct RealtimeOpenAiCompatibleClient {
     cfg: &'static ProviderConfig,
@@ -37,6 +45,9 @@ pub struct RealtimeOpenAiCompatibleClient {
     /// Completions the reorder buffer has released, handed back one per
     /// `poll_event` call.
     ready: VecDeque<StreamingEvent>,
+    /// When the reorder buffer first became head-of-line blocked, for the
+    /// [`Self::check_reorder_timeout`] deadline. `None` while not blocked.
+    blocked_since: Option<Instant>,
 }
 
 impl RealtimeOpenAiCompatibleClient {
@@ -48,6 +59,7 @@ impl RealtimeOpenAiCompatibleClient {
             emit_seq: 0,
             reorder: ReorderBuffer::new(),
             ready: VecDeque::new(),
+            blocked_since: None,
         }
     }
 
@@ -85,20 +97,25 @@ impl RealtimeOpenAiCompatibleClient {
             }
             _ => return Ok(None),
         };
+        // Parse once and reuse for both logging and dispatch.
         // INFO: type + size only (no transcript content — that's user speech and
         // shouldn't land in production logs). DEBUG: full payload (truncated at
         // 600 bytes on a char boundary).
-        let evt_type = serde_json::from_str::<Value>(&text)
+        let parsed = serde_json::from_str::<Value>(&text);
+        let evt_type = parsed
+            .as_ref()
             .ok()
-            .and_then(|v| v.get("type").and_then(|t| t.as_str()).map(str::to_string))
-            .unwrap_or_else(|| "<unparseable>".into());
+            .and_then(|v| v.get("type").and_then(|t| t.as_str()))
+            .unwrap_or("<unparseable>")
+            .to_string();
         log::info!("[Live] WS recv type={} ({} bytes)", evt_type, text.len());
         log::debug!(
             "[Live] WS recv payload: {}",
             truncate_at_char_boundary(&text, 600)
         );
+        let value = parsed.context("parse event json")?;
 
-        match parse_event(&text)? {
+        match parse_event(&value)? {
             WireEvent::Committed { item_id } => {
                 // Capture-order ranking signal — assign the rank now, emit nothing.
                 self.reorder.observe(&item_id);
@@ -117,17 +134,24 @@ impl RealtimeOpenAiCompatibleClient {
         }
     }
 
-    /// True while a completion is held behind an earlier utterance that hasn't
-    /// finished transcribing — the caller arms its skip-head timeout on this.
-    pub fn reorder_blocked(&self) -> bool {
-        self.reorder.is_blocked()
-    }
-
-    /// Abandon a missing head after the caller's timeout and release whatever the
-    /// reorder buffer can now surface, in spoken order.
-    pub fn skip_reorder_head(&mut self) -> Vec<StreamingEvent> {
-        let released = self.reorder.skip_head();
-        self.wrap_completed(released)
+    /// Release any completion held past the head-of-line timeout. The pump calls
+    /// this once per tick with the current instant; the client owns the timer so
+    /// the timeout policy stays with the buffer it guards rather than leaking into
+    /// the audio pump. A merely-slow utterance fills the gap via `poll_event` and
+    /// disarms the timer before it fires; only a dropped/never-arriving earlier
+    /// utterance trips it.
+    pub fn check_reorder_timeout(&mut self, now: Instant) -> Vec<StreamingEvent> {
+        if !self.reorder.is_blocked() {
+            self.blocked_since = None;
+            return Vec::new();
+        }
+        let since = *self.blocked_since.get_or_insert(now);
+        if now.duration_since(since) >= REORDER_HEAD_TIMEOUT {
+            self.blocked_since = None;
+            let released = self.reorder.skip_head();
+            return self.wrap_completed(released);
+        }
+        Vec::new()
     }
 
     /// Release every still-buffered completion in spoken order. Called during the
@@ -169,10 +193,9 @@ fn item_id_of(v: &Value) -> Option<String> {
     v.get("item_id").and_then(|i| i.as_str()).map(str::to_string)
 }
 
-/// Decode a single provider message into a [`WireEvent`]. Pure — all ordering
-/// and sequence-number state lives in the client, not here.
-fn parse_event(text: &str) -> Result<WireEvent> {
-    let v: Value = serde_json::from_str(text).context("parse event json")?;
+/// Decode a single (already-parsed) provider message into a [`WireEvent`]. Pure
+/// — all ordering and sequence-number state lives in the client, not here.
+fn parse_event(v: &Value) -> Result<WireEvent> {
     let evt_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
     match evt_type {
         // Capture-order signals: the provider emits these sequentially as the
@@ -180,7 +203,7 @@ fn parse_event(text: &str) -> Result<WireEvent> {
         // spoken order. Both are observed because providers differ in which they
         // send; whichever names an item_id first sets its rank (idempotent).
         "input_audio_buffer.committed" | "input_audio_buffer.speech_started" => {
-            match item_id_of(&v) {
+            match item_id_of(v) {
                 Some(item_id) => Ok(WireEvent::Committed { item_id }),
                 None => Ok(WireEvent::Ignored),
             }
@@ -195,7 +218,7 @@ fn parse_event(text: &str) -> Result<WireEvent> {
             // Correlate by item_id; fall back to the unique event_id so a provider
             // that omits item_id still gets a distinct (unobserved) rank and emits
             // in arrival order rather than mis-correlating across utterances.
-            let item_id = item_id_of(&v)
+            let item_id = item_id_of(v)
                 .or_else(|| v.get("event_id").and_then(|e| e.as_str()).map(str::to_string))
                 .unwrap_or_default();
             Ok(WireEvent::Completed { item_id, transcript })
@@ -402,10 +425,15 @@ impl RealtimeOpenAiCompatibleClient {
 mod tests {
     use super::*;
 
+    /// Parse a raw JSON event string the way `poll_event` does (decode → dispatch).
+    fn parse(json: &str) -> WireEvent {
+        parse_event(&serde_json::from_str(json).unwrap()).unwrap()
+    }
+
     #[test]
     fn parse_event_completed_carries_item_id_and_transcript() {
         let json = r#"{"type":"conversation.item.input_audio_transcription.completed","item_id":"itm_1","transcript":"hello world"}"#;
-        match parse_event(json).unwrap() {
+        match parse(json) {
             WireEvent::Completed { item_id, transcript } => {
                 assert_eq!(item_id, "itm_1");
                 assert_eq!(transcript, "hello world");
@@ -420,7 +448,7 @@ mod tests {
         // can advance its head past a silent segment; the buffer (not the parser)
         // decides to emit nothing.
         let json = r#"{"type":"conversation.item.input_audio_transcription.completed","item_id":"itm_1","transcript":""}"#;
-        match parse_event(json).unwrap() {
+        match parse(json) {
             WireEvent::Completed { transcript, .. } => assert_eq!(transcript, ""),
             e => panic!("wrong variant: {:?}", e),
         }
@@ -429,7 +457,7 @@ mod tests {
     #[test]
     fn parse_event_committed_is_ranking_signal() {
         let json = r#"{"type":"input_audio_buffer.committed","item_id":"itm_7","previous_item_id":"itm_6"}"#;
-        match parse_event(json).unwrap() {
+        match parse(json) {
             WireEvent::Committed { item_id } => assert_eq!(item_id, "itm_7"),
             e => panic!("wrong variant: {:?}", e),
         }
@@ -438,7 +466,7 @@ mod tests {
     #[test]
     fn parse_event_speech_started_is_ranking_signal() {
         let json = r#"{"type":"input_audio_buffer.speech_started","item_id":"itm_8","audio_start_ms":120}"#;
-        match parse_event(json).unwrap() {
+        match parse(json) {
             WireEvent::Committed { item_id } => assert_eq!(item_id, "itm_8"),
             e => panic!("wrong variant: {:?}", e),
         }
@@ -447,7 +475,7 @@ mod tests {
     #[test]
     fn parse_event_classifies_auth_error() {
         let json = r#"{"type":"error","error":{"message":"invalid key","code":"invalid_api_key"}}"#;
-        match parse_event(json).unwrap() {
+        match parse(json) {
             WireEvent::Error { kind: ErrorKind::AuthFailed, .. } => {}
             e => panic!("wrong variant: {:?}", e),
         }
@@ -456,7 +484,7 @@ mod tests {
     #[test]
     fn parse_event_ignores_unknown_types() {
         let json = r#"{"type":"session.created","session":{"id":"x"}}"#;
-        assert!(matches!(parse_event(json).unwrap(), WireEvent::Ignored));
+        assert!(matches!(parse(json), WireEvent::Ignored));
     }
 
     #[test]

--- a/src-tauri/src/transcription/streaming/realtime_openai_compatible.rs
+++ b/src-tauri/src/transcription/streaming/realtime_openai_compatible.rs
@@ -122,7 +122,7 @@ impl RealtimeOpenAiCompatibleClient {
                 Ok(None)
             }
             WireEvent::Completed { item_id, transcript } => {
-                let released = self.reorder.complete(&item_id, transcript);
+                let released = self.ingest_completed(&item_id, transcript);
                 let events = self.wrap_completed(released);
                 self.ready.extend(events);
                 Ok(self.ready.pop_front())
@@ -132,6 +132,24 @@ impl RealtimeOpenAiCompatibleClient {
             }
             WireEvent::Ignored => Ok(None),
         }
+    }
+
+    /// Feed a completed transcript into the reorder buffer and re-arm the
+    /// head-of-line timer when the head advances. Without this, a completion that
+    /// advances the head onto a *new* still-missing rank (e.g. rank 0 lands while
+    /// rank 1 is still absent) leaves `blocked_since` measuring from the previous
+    /// block, so the new head could be skipped well before its full
+    /// `REORDER_HEAD_TIMEOUT`. Keyed on the head moving — not on text being
+    /// released — so advancing past a silent (empty) rank re-arms it too.
+    fn ingest_completed(&mut self, item_id: &str, transcript: String) -> Vec<String> {
+        let head_before = self.reorder.head();
+        let released = self.reorder.complete(item_id, transcript);
+        if self.reorder.head() != head_before {
+            // Head advanced; clear the clock so the next `check_reorder_timeout`
+            // tick re-arms it fresh for the newly-exposed head.
+            self.blocked_since = None;
+        }
+        released
     }
 
     /// Release any completion held past the head-of-line timeout. The pump calls
@@ -424,6 +442,35 @@ impl RealtimeOpenAiCompatibleClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn head_advance_rearms_reorder_timeout() {
+        // Regression: a completion that advances the head onto a NEW still-missing
+        // rank must restart the head-of-line timer, not inherit the previous
+        // block's clock — otherwise the newly-exposed head is skipped early.
+        let mut c = RealtimeOpenAiCompatibleClient::new(
+            &crate::transcription::streaming::providers::OPENAI_REALTIME,
+        );
+        c.reorder.observe("a"); // rank 0
+        c.reorder.observe("b"); // rank 1 — stays missing
+        c.reorder.observe("c"); // rank 2
+        // rank 2 completes first → blocked on missing rank 0.
+        assert!(c.ingest_completed("c", "C".into()).is_empty());
+        let t0 = Instant::now();
+        assert!(c.check_reorder_timeout(t0).is_empty()); // arms the timer at t0
+        // rank 0 lands → head advances 0→1, still blocked on missing rank 1.
+        assert_eq!(c.ingest_completed("a", "A".into()), vec!["A".to_string()]);
+        // A full timeout after the ORIGINAL block must NOT skip rank 1: its clock
+        // restarted when the head advanced.
+        assert!(
+            c.check_reorder_timeout(t0 + REORDER_HEAD_TIMEOUT).is_empty(),
+            "rank 1's timer must restart on head advance, not inherit rank 0's clock",
+        );
+        // It DOES fire a full timeout measured from the head advance (rank 1
+        // abandoned, rank 2's "C" released).
+        let fired = c.check_reorder_timeout(t0 + REORDER_HEAD_TIMEOUT + REORDER_HEAD_TIMEOUT);
+        assert_eq!(fired.len(), 1);
+    }
 
     /// Parse a raw JSON event string the way `poll_event` does (decode → dispatch).
     fn parse(json: &str) -> WireEvent {

--- a/src-tauri/src/transcription/streaming/reorder.rs
+++ b/src-tauri/src/transcription/streaming/reorder.rs
@@ -94,9 +94,11 @@ impl ReorderBuffer {
     }
 
     /// True when a completion is being held behind a not-yet-completed earlier
-    /// utterance — the signal for the caller to arm its skip-head timeout.
+    /// utterance — the signal for the caller to arm its skip-head timeout. Held
+    /// means there is pending work AND the head itself hasn't completed (were the
+    /// head present, `drain_ready` would already have released it).
     pub fn is_blocked(&self) -> bool {
-        !self.pending.is_empty()
+        !self.pending.is_empty() && !self.pending.contains_key(&self.next_emit)
     }
 
     /// Look up `item_id`'s rank, assigning the next capture-order rank on first sight.

--- a/src-tauri/src/transcription/streaming/reorder.rs
+++ b/src-tauri/src/transcription/streaming/reorder.rs
@@ -101,6 +101,14 @@ impl ReorderBuffer {
         !self.pending.is_empty() && !self.pending.contains_key(&self.next_emit)
     }
 
+    /// The current head-of-line rank (`next_emit`) — the next rank eligible to
+    /// emit. The client compares this before/after a completion to detect when the
+    /// head advanced, so it can re-arm the head-of-line timeout for the
+    /// newly-exposed rank instead of inheriting the previous head's clock.
+    pub fn head(&self) -> u32 {
+        self.next_emit
+    }
+
     /// Look up `item_id`'s rank, assigning the next capture-order rank on first sight.
     fn rank_of(&mut self, item_id: &str) -> u32 {
         if let Some(&rank) = self.ranks.get(item_id) {


### PR DESCRIPTION
## Summary
Follow-up cleanup to the Live out-of-order reorder fix that shipped in #11. Simplifies the reorder client: parse each completion once instead of re-parsing, and fold the reorder timeout handling into the client.

Touches `src-tauri` streaming only — `live.rs`, `realtime_openai_compatible.rs`, `reorder.rs` (-53 / +64).

## Provenance
Originally committed as `96b9efb` on the bilingual feature branch *after* PR #11's merge head, so it was not part of #11. Cherry-picked cleanly onto merged `main`; original authorship preserved.

## Test plan
- [x] `cargo test` — full suite green on top of `main` (189 lib + 6 streaming integration tests, 0 failed)
- [ ] Manual Live-mode out-of-order spot check