### PR TITLE
Fix overlay growth on mixed-DPI displays

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,7 +73,7 @@ Two Tauri windows render the same React bundle but show different views based on
 | `main` | 100×100 | always-on-top, transparent, no taskbar, no decorations, position persisted | Floating mic button |
 | `settings` | 760×800 | hidden by default, resizable, no decorations, position/size persisted | Full settings panel + history |
 
-Both windows persist their position via `tauri-plugin-window-state`. The system tray toggles visibility of the settings window. This keeps the overlay minimal and unobtrusive while still providing a full configuration surface.
+Both windows persist their position via `tauri-plugin-window-state`. The fixed-size overlay skips the plugin's automatic full-state restore and restores only `POSITION` during setup, preventing saved physical dimensions from compounding when the window crosses mixed-DPI monitors. The resizable settings window restores its full state. The system tray toggles visibility of the settings window. This keeps the overlay minimal and unobtrusive while still providing a full configuration surface.
 
 ### 5. Minimal State, Maximum Persistence
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Highlights
+
+- The floating microphone button no longer grows into a large invisible click-blocking area when moved between displays with different scaling
+
+### Fixes
+
+- Stopped restoring persisted size for the fixed-size overlay window, preventing mixed-DPI physical dimensions from compounding across launches. The overlay still restores its saved position, while the resizable settings window continues restoring both position and size.
+
 ## [0.8.6] - 2026-07-31
 
 ### Highlights

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ pub mod transcription;
 use tauri::Manager;
 use tauri::menu::{CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder};
 use tauri::tray::TrayIconBuilder;
+use tauri_plugin_window_state::{StateFlags, WindowExt};
 
 /// Override the Windows minimum window size constraint for a given window.
 /// Windows enforces a minimum width (~136px at 100% DPI) even for undecorated windows.
@@ -134,7 +135,14 @@ pub fn run() {
                 let _ = window.set_focus();
             }
         }))
-        .plugin(tauri_plugin_window_state::Builder::new().build())
+        .plugin(
+            tauri_plugin_window_state::Builder::new()
+                // The overlay is fixed-size. Restoring its persisted physical size can
+                // compound DPI scaling when it moves between monitors, so setup restores
+                // only its position below. Other windows keep the default full restore.
+                .skip_initial_state("main")
+                .build(),
+        )
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
@@ -158,11 +166,17 @@ pub fn run() {
             let app_handle = app.handle().clone();
             database::init(&app_handle)?;
 
-            // Override Windows minimum window size for the overlay
-            #[cfg(windows)]
+            // Restore the overlay location without restoring its fixed size.
             if let Some(main_window) = app.get_webview_window("main") {
-                override_min_window_size(&main_window, 100, 100);
-                let _ = main_window.show();
+                // Keep the user's chosen monitor/location without allowing a stale or
+                // mixed-DPI window-state entry to override the configured 100x100 size.
+                let _ = main_window.restore_state(StateFlags::POSITION);
+                #[cfg(windows)]
+                {
+                    // Override Windows' minimum window size for the overlay.
+                    override_min_window_size(&main_window, 100, 100);
+                    let _ = main_window.show();
+                }
             }
 
             // Settings window starts hidden — opened via tray


### PR DESCRIPTION
Stops automatic full-state restore for the fixed-size overlay and restores only its saved position, preventing persisted physical dimensions from compounding across mixed-DPI launches. The resizable settings window continues restoring its full state. Verification: cargo test (208 unit tests and 6 integration tests); cargo clippy (completed with pre-existing warnings only); targeted rustfmt and git diff checks. Closes #13.